### PR TITLE
Add new setting to toggle "IncludeJS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,9 @@ To use it, just use the `obfuscateEmail` Twig filter on any text field or string
 ```
 
 ## Configuring the Plugin
+### InludeJS
+By default the plugin inserts the necessary JavaScript to your front end html. There is a setting to turn this off if you want to include the JS code manually. The relevant JS code is available at https://github.com/Propaganistas/Email-Obfuscator/tree/master/assets
 
-There are no settings right now. 
-
-## Roadmap
-- There might be some options to choose from with regard to how to include the javascript code.
 
 ## Credits
 - [Propaganistas](https://github.com/Propaganistas) for developing this great Twig Extension

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "extra": {
         "name": "Craft Emailobfuscator",
         "handle": "craft-emailobfuscator",
-        "hasCpSettings": false,
+        "hasCpSettings": true,
         "hasCpSection": false,
         "changelogUrl": "https://raw.githubusercontent.com/luke-nehemedia/craft-emailobfuscator/master/CHANGELOG.md",
         "class": "lucasbares\\craftemailobfuscator\\CraftEmailobfuscator"

--- a/src/CraftEmailobfuscator.php
+++ b/src/CraftEmailobfuscator.php
@@ -10,6 +10,8 @@
 
 namespace lucasbares\craftemailobfuscator;
 
+use lucasbares\craftemailobfuscator\models\Settings;
+
 use Craft;
 use craft\base\Plugin;
 use craft\services\Plugins;
@@ -53,7 +55,9 @@ class CraftEmailobfuscator extends Plugin
         self::$plugin = $this;
 
         // registering the AssetBundle with propaganistas js file
-        $this->view->registerAssetBundle(CraftEmailobfuscatorPropaganistasAssets::class);
+        if( $this->settings->includeJS ) {
+            $this->view->registerAssetBundle(CraftEmailobfuscatorPropaganistasAssets::class);
+        }
 
         // registering propaganistas email obfuscator
         Craft::$app->view->registerTwigExtension(new \Propaganistas\EmailObfuscator\Twig\Extension);
@@ -73,4 +77,29 @@ class CraftEmailobfuscator extends Plugin
         Craft::info( Craft::t('craft-emailobfuscator', 'plugin-loaded'),__METHOD__ );
     }
 
+    // Protected Methods
+    // =========================================================================
+
+    /**
+     * Creates settings model
+     *
+     * @return Settings
+     */
+
+    protected function createSettingsModel(): Settings
+    {
+        return new Settings();
+    }
+
+    /**
+     * Settings HTML
+     *
+     * @return string The rendered settings HTML
+     */
+    protected function settingsHtml(): string
+    {
+        return Craft::$app->view->renderTemplate('craft-emailobfuscator/settings', [
+            'settings' => $this->getSettings()
+        ]);
+    }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Craft Emailobfuscator plugin for Craft CMS 3.x
+ *
+ * A simple plugin that adds a twig tag to obfuscate email addresses (by rot13) in text fields.
+ *
+ * @link      http://luke.nehemedia.de
+ * @copyright Copyright (c) 2018 Lucas Bares
+ */
+
+namespace lucasbares\craftemailobfuscator\models;
+
+use craft\base\Model;
+
+class Settings extends Model
+{
+    public $includeJS = true;
+}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -1,0 +1,9 @@
+{% import "_includes/forms" as forms %}
+
+{{ forms.lightswitchField({
+    label: "Include JS-file"|t('craft-emailobfuscator'),
+    instructions: "By default the plugin inserts the necessary JavaScript to your front end html. You can turn this off if you want to include the JS file manually."|t('craft-emailobfuscator'),
+    id: 'includeJS',
+    name: 'includeJS',
+    on: settings.includeJS })
+}}


### PR DESCRIPTION
Tweaking performance for a project I needed to inline all small JS snippets. I also then noticed that something like this might be planed, so...

It's a simple lightswitch setting that allows the user to disable registering the asset bundle if they want to include the front end JS code manually.